### PR TITLE
Add interactive joke fetching on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,12 +10,60 @@
     <link rel="stylesheet" href="style.css" />
     <meta charset="UTF-8" />
     <title>Joke Generator</title>
-</head>
-<body class="home">
-<main class="home__hero">
-    <h1 class="home__title">Joke Generator</h1>
-    <p class="home__subtitle">Need a smile? Press the button and let the punchlines roll.</p>
-    <a class="generateAJokeButton" href="jokes.html">Generate a joke</a>
-</main>
-</body>
+  </head>
+  <body class="home">
+    <main class="home__hero" aria-live="polite">
+      <h1 class="home__title">Joke Generator</h1>
+      <p class="home__subtitle">
+        Need a smile? Press the button and let the punchlines roll.
+      </p>
+      <article class="joke-panel">
+        <p class="joke-panel__prompt">
+          Press the button to get your first joke.
+        </p>
+        <p class="joke-panel__setup" hidden></p>
+        <p class="joke-panel__punchline" hidden></p>
+      </article>
+      <button class="generateAJokeButton" type="button">
+        Get another joke
+      </button>
+    </main>
+    <script>
+      const jokeButton = document.querySelector(".generateAJokeButton");
+      const promptEl = document.querySelector(".joke-panel__prompt");
+      const setupEl = document.querySelector(".joke-panel__setup");
+      const punchlineEl = document.querySelector(".joke-panel__punchline");
+      const API_URL = "https://official-joke-api.appspot.com/jokes/random";
+
+      async function fetchJoke() {
+        jokeButton.disabled = true;
+        jokeButton.textContent = "Loading...";
+        promptEl.hidden = false;
+        promptEl.textContent = "Fetching something funny…";
+        setupEl.hidden = true;
+        punchlineEl.hidden = true;
+        try {
+          const response = await fetch(API_URL);
+          if (!response.ok) {
+            throw new Error(`Request failed with ${response.status}`);
+          }
+          const { setup, punchline } = await response.json();
+          promptEl.hidden = true;
+          setupEl.hidden = false;
+          punchlineEl.hidden = false;
+          setupEl.textContent = setup;
+          punchlineEl.textContent = punchline;
+        } catch (error) {
+          promptEl.hidden = false;
+          promptEl.textContent =
+            "Hmm, the punchline got lost. Try again in a moment.";
+        } finally {
+          jokeButton.disabled = false;
+          jokeButton.textContent = "Get another joke";
+        }
+      }
+
+      jokeButton.addEventListener("click", fetchJoke);
+    </script>
+  </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,69 +1,109 @@
 body {
-    margin: 0;
-    min-height: 100vh;
-    font-family: "Poppins", sans-serif;
-    font-weight: 400;
-    font-style: normal;
-    background: linear-gradient(160deg, #c8eef6 0%, #e5f8fd 55%, #ffffff 100%);
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Poppins", sans-serif;
+  font-weight: 400;
+  font-style: normal;
+  background: linear-gradient(160deg, #c8eef6 0%, #e5f8fd 55%, #ffffff 100%);
 }
 
 .home {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 48px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 24px;
 }
 
 .home__hero {
-    text-align: center;
-    max-width: 540px;
-    padding: 48px 40px;
-    background-color: rgba(255, 255, 255, 0.85);
-    border-radius: 20px;
-    border: 1px solid rgba(3, 4, 93, 0.08);
-    box-shadow: 0 24px 60px rgba(0, 118, 181, 0.15);
-    backdrop-filter: blur(4px);
+  text-align: center;
+  max-width: 540px;
+  padding: 48px 40px;
+  background-color: rgba(255, 255, 255, 0.85);
+  border-radius: 20px;
+  border: 1px solid rgba(3, 4, 93, 0.08);
+  box-shadow: 0 24px 60px rgba(0, 118, 181, 0.15);
+  backdrop-filter: blur(4px);
 }
 
 .home__title {
-    margin: 0;
-    font-size: clamp(2.5rem, 5vw, 3.5rem);
-    letter-spacing: 0.02em;
-    color: #03045d;
+  margin: 0;
+  font-size: clamp(2.5rem, 5vw, 3.5rem);
+  letter-spacing: 0.02em;
+  color: #03045d;
 }
 
 .home__subtitle {
-    margin: 16px 0 36px;
-    font-size: 1.1rem;
-    line-height: 1.6;
-    color: rgba(3, 4, 93, 0.75);
+  margin: 16px 0 36px;
+  font-size: 1.1rem;
+  line-height: 1.6;
+  color: rgba(3, 4, 93, 0.75);
+}
+
+.joke-panel {
+  margin-bottom: 36px;
+  padding: 28px;
+  border-radius: 16px;
+  background: rgba(3, 4, 93, 0.05);
+  border: 1px solid rgba(3, 4, 93, 0.12);
+  color: rgba(3, 4, 93, 0.85);
+  line-height: 1.7;
+}
+
+.joke-panel__prompt {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 500;
+  color: rgba(3, 4, 93, 0.65);
+}
+
+.joke-panel__setup,
+.joke-panel__punchline {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.joke-panel__setup {
+  font-weight: 600;
+}
+
+.joke-panel__punchline {
+  margin-top: 16px;
 }
 
 .generateAJokeButton {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: 16px 32px;
-    font-size: 1.25rem;
-    font-weight: 600;
-    text-decoration: none;
-    color: #ffffff;
-    background: linear-gradient(135deg, #03045d, #0076b5);
-    border-radius: 999px;
-    border: none;
-    box-shadow: 0 14px 25px rgba(0, 118, 181, 0.35);
-    cursor: pointer;
-    transform: translateY(0);
-    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px 32px;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #ffffff;
+  background: linear-gradient(135deg, #03045d, #0076b5);
+  border-radius: 999px;
+  border: none;
+  box-shadow: 0 14px 25px rgba(0, 118, 181, 0.35);
+  cursor: pointer;
+  transform: translateY(0);
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease,
+    background 0.2s ease;
 }
 
 .generateAJokeButton:hover {
-    background: linear-gradient(135deg, #012759, #0091cf);
-    transform: translateY(-4px);
-    box-shadow: 0 18px 35px rgba(0, 118, 181, 0.4);
+  background: linear-gradient(135deg, #012759, #0091cf);
+  transform: translateY(-4px);
+  box-shadow: 0 18px 35px rgba(0, 118, 181, 0.4);
 }
 
 .generateAJokeButton:active {
-    transform: translateY(-1px);
-    box-shadow: 0 10px 18px rgba(0, 118, 181, 0.3);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px rgba(0, 118, 181, 0.3);
+}
+
+.generateAJokeButton:disabled {
+  cursor: wait;
+  transform: translateY(0);
+  box-shadow: 0 10px 18px rgba(0, 118, 181, 0.2);
+  background: linear-gradient(135deg, #6b8fbc, #7ba8cf);
 }


### PR DESCRIPTION
This pull request updates the `Joke Generator` app to generate and display jokes directly on the homepage, improving user experience and accessibility. The main changes include replacing the link to a separate jokes page with an interactive joke panel, adding JavaScript to fetch jokes from an API, and updating the styling to support the new layout and states.

**Frontend functionality and accessibility:**

* Replaced the "Generate a joke" link with an interactive button that fetches and displays jokes directly on the homepage, eliminating the need for navigation to a separate page. Added a `joke-panel` section to show the prompt, setup, and punchline, and improved accessibility with `aria-live="polite"`.
* Added JavaScript to fetch jokes from the Official Joke API, handle loading and error states, and update the UI dynamically when the button is clicked.

**Styling enhancements:**

* Introduced new CSS classes for `.joke-panel`, `.joke-panel__prompt`, `.joke-panel__setup`, and `.joke-panel__punchline` to style the joke display area and its contents.
* Updated `.generateAJokeButton` styles to support the new button state, including a disabled state with a visual indicator while loading a joke.