### PR TITLE
introduce category cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,30 +24,90 @@
         <p class="joke-panel__setup" hidden></p>
         <p class="joke-panel__punchline" hidden></p>
       </article>
-      <button class="generateAJokeButton" type="button">
-        Get another joke
-      </button>
+      <div class="joke-controls">
+        <button class="generateAJokeButton" type="button">
+          Get another joke
+        </button>
+        <div
+          class="category-pills"
+          role="group"
+          aria-label="Pick a joke category (optional)"
+        >
+          <button
+            class="category-pill is-active"
+            type="button"
+            data-category="random"
+          >
+            Random
+          </button>
+          <button class="category-pill" type="button" data-category="general">
+            General
+          </button>
+          <button
+            class="category-pill"
+            type="button"
+            data-category="programming"
+          >
+            Programming
+          </button>
+          <button
+            class="category-pill"
+            type="button"
+            data-category="knock-knock"
+          >
+            Knock Knock
+          </button>
+        </div>
+      </div>
     </main>
     <script>
       const jokeButton = document.querySelector(".generateAJokeButton");
       const promptEl = document.querySelector(".joke-panel__prompt");
       const setupEl = document.querySelector(".joke-panel__setup");
       const punchlineEl = document.querySelector(".joke-panel__punchline");
-      const API_URL = "https://official-joke-api.appspot.com/jokes/random";
+      const API_ROOT = "https://official-joke-api.appspot.com/jokes";
+      const categoryButtons = Array.from(
+        document.querySelectorAll(".category-pill"),
+      );
+      let activeCategory = "random";
+
+      function setActiveCategory(category) {
+        activeCategory = category;
+        categoryButtons.forEach((button) => {
+          const isActive = button.dataset.category === category;
+          button.classList.toggle("is-active", isActive);
+        });
+      }
+      setActiveCategory(activeCategory);
+
+      function buildJokeUrl() {
+        if (!activeCategory || activeCategory === "random") {
+          return `${API_ROOT}/random`;
+        }
+        return `${API_ROOT}/${activeCategory}/random`;
+      }
 
       async function fetchJoke() {
         jokeButton.disabled = true;
         jokeButton.textContent = "Loading...";
+        categoryButtons.forEach((button) => {
+          button.disabled = true;
+        });
         promptEl.hidden = false;
         promptEl.textContent = "Fetching something funny…";
         setupEl.hidden = true;
         punchlineEl.hidden = true;
         try {
-          const response = await fetch(API_URL);
+          const response = await fetch(buildJokeUrl());
           if (!response.ok) {
             throw new Error(`Request failed with ${response.status}`);
           }
-          const { setup, punchline } = await response.json();
+          const payload = await response.json();
+          const joke = Array.isArray(payload) ? payload[0] : payload;
+          if (!joke?.setup || !joke?.punchline) {
+            throw new Error("No joke returned");
+          }
+          const { setup, punchline } = joke;
           promptEl.hidden = true;
           setupEl.hidden = false;
           punchlineEl.hidden = false;
@@ -60,10 +120,26 @@
         } finally {
           jokeButton.disabled = false;
           jokeButton.textContent = "Get another joke";
+          categoryButtons.forEach((button) => {
+            button.disabled = false;
+          });
         }
       }
 
+      function handleCategoryClick(event) {
+        const { category } = event.currentTarget.dataset;
+        if (!category || category === activeCategory) {
+          fetchJoke();
+          return;
+        }
+        setActiveCategory(category);
+        fetchJoke();
+      }
+
       jokeButton.addEventListener("click", fetchJoke);
+      categoryButtons.forEach((button) => {
+        button.addEventListener("click", handleCategoryClick);
+      });
     </script>
   </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -70,6 +70,20 @@ body {
   margin-top: 16px;
 }
 
+.joke-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: center;
+}
+
+.category-pills {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 12px;
+}
+
 .generateAJokeButton {
   display: inline-flex;
   align-items: center;
@@ -106,4 +120,39 @@ body {
   transform: translateY(0);
   box-shadow: 0 10px 18px rgba(0, 118, 181, 0.2);
   background: linear-gradient(135deg, #6b8fbc, #7ba8cf);
+}
+
+.category-pill {
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px solid rgba(3, 4, 93, 0.18);
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow: 0 8px 18px rgba(0, 118, 181, 0.18);
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: rgba(3, 4, 93, 0.7);
+  cursor: pointer;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease,
+    background 0.2s ease,
+    color 0.2s ease;
+}
+
+.category-pill:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 12px 24px rgba(0, 118, 181, 0.28);
+}
+
+.category-pill.is-active {
+  background: linear-gradient(135deg, #03045d, #0076b5);
+  color: #ffffff;
+  border-color: transparent;
+}
+
+.category-pill:disabled {
+  cursor: wait;
+  opacity: 0.75;
+  transform: none;
+  box-shadow: 0 6px 14px rgba(0, 118, 181, 0.14);
 }


### PR DESCRIPTION
This pull request adds the ability for users to select a joke category (Random, General, Programming, or Knock Knock) when generating a joke, improving both the interactivity and user experience of the Joke Generator. The UI is updated with new category pill buttons, and the logic for fetching jokes is enhanced to support category-based requests. Styling is also updated to visually support the new controls.

**Feature: Joke Category Selection**

- Added a set of category pill buttons (`Random`, `General`, `Programming`, `Knock Knock`) below the "Get another joke" button, allowing users to pick a joke category. The active category is visually highlighted, and the app fetches jokes based on the selected category.
- Updated the joke-fetching logic to build the API URL dynamically based on the selected category, and adjusted the response handling to support the API's payload structure.
- Implemented event handling for category pill clicks, including updating the active category, fetching a new joke, and managing button disabled states during loading.

**UI/UX Improvements**

- Introduced new CSS classes for `.joke-controls`, `.category-pills`, and `.category-pill` to lay out the controls and style the category selection buttons, including hover, active, and disabled states for better user feedback. [[1]](diffhunk://#diff-b78be019f1dc6d57753ea900c3805b114cd53ab7c0db836cc081836df1b99b7aR73-R86) [[2]](diffhunk://#diff-b78be019f1dc6d57753ea900c3805b114cd53ab7c0db836cc081836df1b99b7aR124-R158)
<img width="594" height="573" alt="Screenshot 2025-10-06 at 21 06 00" src="https://github.com/user-attachments/assets/939b9726-a1bd-4d58-a3e9-51c4936edd45" />
